### PR TITLE
Adjust build script and properties for use with dual audio releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,11 @@ fun EventLine.isBlank(): Boolean {
     return this.text.isEmpty() && this.actor.isEmpty() && this.effect.isEmpty()
 }
 
+// Check if a line is dialogue
+fun EventLine.isDialogue(): Boolean {
+    return Regex("Main|Default|Alt") in this.style
+}
+
 subs {
     readProperties("sub.properties")
     episodes(getList("episodes"))
@@ -84,6 +89,14 @@ subs {
         ass { events.lines.removeIf { it.isBlank() } }
     }
 
+    // Remove dialogue lines from forced Signs & Song tracks
+    val forced by task<ASS> {
+        from(cleanmerge.item())
+        ass {
+            events.lines.removeIf { it.isDialogue() }
+        }
+    }
+
     // Generate chapters from dialogue file
     chapters {
         from(get("chapters"))
@@ -117,9 +130,16 @@ subs {
                 default(true)
             }
 
-            audio {
+            audio(0) {
                 lang("jpn")
-                name(get("atrack"))
+                name(get("atrack_jpn"))
+                default(true)
+                forced(false)
+            }
+
+            audio(1) {
+                lang("eng")
+                name(get("atrack_eng"))
                 default(true)
                 forced(false)
             }
@@ -144,6 +164,16 @@ subs {
                 name(get("strack_hono"))
                 default(true)
                 forced(false)
+                compression(CompressionType.ZLIB)
+            }
+        }
+
+        from(forced.item()) {
+            tracks {
+                lang("eng")
+                name(get("strack_ss"))
+                default(false)
+                forced(true)
                 compression(CompressionType.ZLIB)
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,11 +90,16 @@ subs {
     }
 
     // Remove dialogue lines from forced Signs & Song tracks
-    val forced by task<ASS> {
+    val strip_dialogue by task<ASS> {
         from(cleanmerge.item())
         ass {
             events.lines.removeIf { it.isDialogue() }
         }
+    }
+    // and merge in the forced track (if present)
+    val forced by task<Merge> {
+        fromIfPresent(get("forced"), ignoreMissingFiles = true)
+        from(strip_dialogue.item())
     }
 
     // Generate chapters from dialogue file

--- a/sub.properties
+++ b/sub.properties
@@ -43,6 +43,7 @@ dialogue=${episode}/${shorthand} ${episode} - Dialogue.ass
 extra=${episode}/${shorthand} ${episode} - Extra.ass
 TS=${episode}/${shorthand} ${episode} - TS*.ass
 INS=${episode}/${shorthand} ${episode} - INS*.ass
+forced=${episode}/${shorthand} ${episode} - Forced.ass
 render_warning=common/warning.ass
 
 

--- a/sub.properties
+++ b/sub.properties
@@ -15,9 +15,11 @@ codec_info=${format} ${vcodec} ${acodec}
 
 # Specific names for individual tracks. Should match codec info.
 vtrack=x265
-atrack=Opus 2.0 @ 192 kb/s
+atrack_jpn=Opus 2.0 @ 192 kb/s
+atrack_eng=Opus 2.0 @ 192 kb/s
 strack_reg=Full Subtitles [${group}]
 strack_hono=Honorifics [${group}]
+strack_ss=Signs & Songs [${group}]
 
 
 # Show-related (output) files


### PR DESCRIPTION
Possibly not the most elegant approach, but adds functions for merging S&S tracks, configures mux function and sub properties file for two audio tracks and S&S sub track.

Of note, muxing the S&S track requires opsync/edsync lines to be in files other than dialogue.

(Not strictly tested but made based on a separate multi-audio project repo that I know does work. If things are broken, yell at me.)