### PR TITLE
Add GitHub Actions workflow to run test mux on push

### DIFF
--- a/.github.sample/workflows/test-mux.yaml
+++ b/.github.sample/workflows/test-mux.yaml
@@ -1,0 +1,35 @@
+name: Test Mux
+
+on:
+  push
+
+jobs:
+  mux:
+    strategy:
+      matrix:
+        # Fill this out with the list of episodes to check
+        # (matches SubKt; exclude episodes that aren't yet muxable or otherwise shouldn't be checked)
+        episode: ["01", "02", "03"]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "temurin"
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Install dependencies
+        run: sudo apt install -y ffmpeg mkvtoolnix
+      - name: Create dummy video
+        run: |
+          ffmpeg -t 10 -s 1920x1080 -f rawvideo -pix_fmt yuv420p -r 24000/1001 -i /dev/zero -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 -shortest blank.mp4
+          mkvmerge -o '${{ matrix.episode }}/${{ matrix.episode }} (Premux).mkv' blank.mp4
+          rm blank.mp4
+      - name: Mux with SubKt
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: mux.${{ matrix.episode }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ on a per-project basis:
   - (Optional) `warning.ass`: A subtitle file that contains a warning to display in players that don't support ASS tags properly.
   - `fonts/`: Directory containing common fonts, such as dialogue fonts.
 
+- **.github.sample/workflows/**: GitHub Actions workflows. Remove `.sample` from the directory name.
+
+  - `test-mux.yaml`: A workflow that attempts to run a test mux on each episode on every push to the repo.
+
 ## Getting Started
 
 To get started with this template:


### PR DESCRIPTION
This workflow will run on every push to the repo. Manual intervention is required to get this running properly:
- Rename `.github.sample` to `.github`
  - `.sample` is necessary to prevent GitHub from recognizing the directory as workflows for _this_ repo.
- Edit the workflow to check the desired episodes.
  - Generally speaking, you will only want to check episodes that are actually muxable at minimum. Any episode that has not had any progress started should probably be excluded from the list until it's muxable.

Caveats:
- This workflow will mux every configured episode on every push regardless of whether the episode is affected or not.
  - It is possible to dynamically set the matrix values based on changed paths, but care must be taken to ensure that episodes depend on changes in common paths in addition to episode-specific paths.
- This workflow likely does not play well with aegisub-cli and will have to be adjusted to include it. In particular, a step to install the Aegisub dependency is needed.
  - A better solution may be to create a Docker image with the required tools and have the workflow run on that.
- Private repos have usage limits. This may or may not be an issue depending on the frequency of pushes.

This workflow is based on the ButterFS workflow for Hataraku Saibou: https://github.com/butterfansubs/hataraku-saibou/blob/8ec814aa796539c4838faad1e3cf7c97f223b99a/.github/workflows/main-s2.yaml